### PR TITLE
fix: Find project for existing key correctly

### DIFF
--- a/controllers/projectkey_controller.go
+++ b/controllers/projectkey_controller.go
@@ -197,7 +197,9 @@ func (r *ProjectKeyReconciler) getExistingState(projectkey sentryv1alpha1.Projec
 			projectSlug = sProject.Slug
 			break
 		}
+	}
 
+	if projectSlug == "" {
 		return nil, "", ErrOutOfSync
 	}
 


### PR DESCRIPTION


## Description

The error would always be returned if the first entry in the project list wasn't the one we were looking for. Instead, check all entries, then error if it wasn't found

Fixes #1

<!-- A clear and concise summary of the changes you have made, including any relevant motivation and context. -->

<!-- List the dependencies that are required for this change, if any. -->

<!-- Also include any issues that this pull request addresses. -->

## Additional context

<!-- Add any other information that's important and relevant to your pull request here, such as benchmarks or screenshots. -->
